### PR TITLE
FLOE-219: Fixed unit tests in safari and chrome

### DIFF
--- a/src/components/metadata/js/resourceInputPanel.js
+++ b/src/components/metadata/js/resourceInputPanel.js
@@ -192,7 +192,7 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
                     },
                     modelListeners: {
                         // could be changed to "" when updated to the new model relay system
-                        "*": {
+                        "": {
                             func: "{baseResourceInputPanel}.updateModel",
                             args: ["{change}.value", "{change}.path", "{that}.options.source.2"]
                         }
@@ -326,7 +326,8 @@ https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
     };
 
     gpii.metadata.baseResourceInputPanel.updateModel = function (that, value, path, index, root) {
-        var changePath = [root, index, path].join(".");
+        path = that.applier.parseEL() || [];
+        var changePath = [root, index].concat(path);
         that.applier.change(changePath, value);
     };
 

--- a/tests/components/metadata/js/captionsPanelTests.js
+++ b/tests/components/metadata/js/captionsPanelTests.js
@@ -13,6 +13,20 @@ https://github.com/gpii/universal/LICENSE.txt
 
     fluid.registerNamespace("gpii.tests");
 
-    gpii.tests.testResourceInputPanel(gpii.metadata.captionsPanel, ".gpiic-captionsPanel", "captionsPanel");
+    fluid.defaults("gpii.tests.captionsPanelTests", {
+        gradeNames: ["gpii.tests.resourceInputPanelTests", "autoInit"],
+        components: {
+            resourceInputPanel: {
+                type: "gpii.metadata.captionsPanel",
+                container: ".gpiic-captionsPanel"
+            }
+        }
+    });
+
+    $(document).ready(function () {
+        fluid.test.runTests([
+            "gpii.tests.captionsPanelTests"
+        ]);
+    });
 
 })(jQuery, fluid);

--- a/tests/components/metadata/js/resourceInputPanelTests.js
+++ b/tests/components/metadata/js/resourceInputPanelTests.js
@@ -44,7 +44,7 @@ https://github.com/gpii/universal/LICENSE.txt
     };
 
     gpii.tests.changeLanguage = function (that, newLanguageValue) {
-        that.locate("languages").find("[value='" + newLanguageValue + "']").attr("selected", "selected").change();
+        that.locate("languages").find("[value='" + newLanguageValue + "']").prop("selected", "selected").change();
     };
 
     gpii.tests.checkModelValue = function (newSrcValue) {
@@ -246,11 +246,10 @@ https://github.com/gpii/universal/LICENSE.txt
         gpii.tests.resrouceInputPanelInitializationTest(".gpiic-resourceInputPanel-init");
     });
 
-    gpii.tests.testResourceInputPanel(gpii.metadata.resourceInputPanel, ".gpiic-resourceInputPanel", "resourceInputPanel");
-
     $(document).ready(function () {
         fluid.test.runTests([
-            "gpii.tests.resourceInputTests"
+            "gpii.tests.resourceInputTests",
+            "gpii.tests.resourceInputPanelTests"
         ]);
     });
 

--- a/tests/components/metadata/js/transcriptsPanelTests.js
+++ b/tests/components/metadata/js/transcriptsPanelTests.js
@@ -13,6 +13,20 @@ https://github.com/gpii/universal/LICENSE.txt
 
     fluid.registerNamespace("gpii.tests");
 
-    gpii.tests.testResourceInputPanel(gpii.metadata.transcriptsPanel, ".gpiic-transcriptsPanel", "transcriptsPanel");
+    fluid.defaults("gpii.tests.transcriptsPanelTests", {
+        gradeNames: ["gpii.tests.resourceInputPanelTests", "autoInit"],
+        components: {
+            resourceInputPanel: {
+                type: "gpii.metadata.transcriptsPanel",
+                container: ".gpiic-transcriptsPanel"
+            }
+        }
+    });
+
+    $(document).ready(function () {
+        fluid.test.runTests([
+            "gpii.tests.transcriptsPanelTests"
+        ]);
+    });
 
 })(jQuery, fluid);


### PR DESCRIPTION
Addressed the failing unit tests that were failing in chrome. This included rewriting the resourceInputPanel tests in the IoC Testing framework style.

http://issues.fluidproject.org/browse/FLOE-219
