### PR TITLE
FLOE-208: Adding overview panel to feedback demo

### DIFF
--- a/demos/feedback/css/feedbackDemo.css
+++ b/demos/feedback/css/feedbackDemo.css
@@ -35,6 +35,12 @@ video {
     line-height: inherit;
 }
 
+/* Shift the preference status icons to the right to prevent overlap from overview panel icon */
+
+.gpii-feedbackDemo .gpii-feedback-preferencesStatus {
+    padding: 0px 0px 0px 3.5rem;
+}
+
 /* Header area */
 
 .gpii-feedbackDemo-header {

--- a/demos/feedback/css/feedbackDemo.css
+++ b/demos/feedback/css/feedbackDemo.css
@@ -38,7 +38,7 @@ video {
 /* Shift the preference status icons to the right to prevent overlap from overview panel icon */
 
 .gpii-feedbackDemo .gpii-feedback-preferencesStatus {
-    padding: 0px 0px 0px 3.5rem;
+    padding: 0px 0px 0px 5rem;
 }
 
 /* Header area */

--- a/demos/feedback/html/overviewPanelTemplate.html
+++ b/demos/feedback/html/overviewPanelTemplate.html
@@ -1,0 +1,49 @@
+<div class="fl-overviewPanel">
+    <div class="fl-overviewPanel-icon-fluidStar">
+        <a class="flc-overviewPanel-toggleControl" href="#"></a>
+    </div>
+    <div class="fl-overviewPanel-body fl-overviewPanel-group">
+        <div class="fl-overviewPanel-title">
+            <h1><span class="flc-overviewPanel-title-begin"></span> <a class="flc-overviewPanel-titleLink" href="#" target="_blank"><span class="flc-overviewPanel-title-linkText"></span></a> <span class="flc-overviewPanel-title-end"></span></h1>
+        </div>
+
+        <div class="fl-overviewPanel-contents">
+            <span class="flc-overviewPanel-componentName fl-overviewPanel-componentName"></span>
+            <div class="flc-overviewPanel-description fl-overviewPanel-description"></div>
+            <div class="fl-overviewPanel-instructions">
+                <h2><span class="flc-overviewPanel-instructionsHeading"></span></h2>
+                <div class="flc-overviewPanel-instructions"></div>
+            </div>
+        </div>
+
+        <div class="fl-overviewPanel-footer">
+            <div class="fl-overviewPanel-links">
+                <ul>
+                    <li>
+                        <a class="flc-overviewPanel-demoCodeLink" href="#">
+                            <div class="fl-overviewPanel-iconContainer"><span class="fl-overviewPanel-links-icon fl-overviewPanel-links-icon-code"></span></div>
+                            <span class="flc-overviewPanel-demoCodeLinkText fl-overviewPanel-demoCodeLinkText"></span>
+                        </a>
+                    </li>
+                    <li>
+                        <a class="flc-overviewPanel-designLink" href="#">
+                            <div class="fl-overviewPanel-iconContainer"><span class="fl-overviewPanel-links-icon fl-overviewPanel-links-icon-design"></span></div>
+                                <span class="flc-overviewPanel-designLinkText fl-overviewPanel-designLinkText"></span>
+                        </a>
+                    </li>
+                    <li>
+                        <a class="flc-overviewPanel-infusionCodeLink" href="#">
+                            <div class="fl-overviewPanel-iconContainer"><span class="fl-overviewPanel-links-icon fl-overviewPanel-links-icon-github"></span></div>
+                            <span class="flc-overviewPanel-infusionCodeLinkText fl-overviewPanel-infusionCodeLinkText"></span>
+                        </a>
+                    </li>
+                </ul>
+                <div class="fl-overviewPanel-feedback-link">
+                    <span class="flc-overviewPanel-feedbackText fl-overviewPanel-feedbackText"></span><br/>
+                    <a class="flc-overviewPanel-feedbackLink" href="#"><span class="flc-overviewPanel-feedbackLinkText"></span></a>
+                </div>
+            </div>
+            <a class="flc-overviewPanel-closeControl fl-overviewPanel-closeControl" href="#"><span class="flc-overviewPanel-closeText"></span></a>
+        </div>
+    </div>
+</div>

--- a/demos/feedback/index.html
+++ b/demos/feedback/index.html
@@ -11,6 +11,7 @@
 
         <link rel="stylesheet" href="../../src/lib/infusion/src/components/overviewPanel/css/OverviewPanel.css" />
         <link rel="stylesheet" href="../../src/components/feedback/css/feedback.css" />
+        <link rel="stylesheet" href="../shared/css/overviewPanel.css" />
         <link rel="stylesheet" href="css/feedbackDemo.css" />
 
         <!-- Required CSS files for UI Options -->
@@ -31,6 +32,7 @@
         <link rel="stylesheet" type="text/css" href="../../src/lib/infusion/src/lib/jquery/ui/css/fl-theme-dglg/dglg.css" />
         <link rel="stylesheet" type="text/css" href="../../src/lib/infusion/src/framework/preferences/css/PrefsEditor.css" />
         <link rel="stylesheet" type="text/css" href="../../src/lib/infusion/src/framework/preferences/css/SeparatedPanelPrefsEditor.css" />
+        <link rel="stylesheet" href="../../src/lib/infusion/src/components/overviewPanel/css/OverviewPanel.css" />
 
         <script type="text/javascript" src="../../src/lib/infusion/infusion-custom.js"></script>
         <script type="text/javascript" src="../../src/lib/pouchDB/pouchdb.js"></script>
@@ -39,8 +41,11 @@
         <script type="text/javascript" src="../../src/components/feedback/js/bindDialog.js"></script>
         <script type="text/javascript" src="../../src/components/feedback/js/matchConfirmation.js"></script>
         <script type="text/javascript" src="../../src/components/feedback/js/feedback.js"></script>
+        <script type="text/javascript" src="js/feedbackDemo.js"></script>
     </head>
-    <body class="gpii-feedbackDemo">
+    <body class="gpii-feedbackDemo gpii-demo">
+        <div class="flc-overviewPanel fl-overviewPanel-container"></div>
+
         <!-- BEGIN markup for feedback tool -->
 
         <section class="gpiic-feedback">
@@ -122,35 +127,5 @@
                 emissions the impacts are expected to become increasingly worse.</p>
             </div>
         </main>
-
-        <script type="text/javascript">
-            $(document).ready(function () {
-                fluid.uiOptions.prefsEditor(".flc-prefsEditor-separatedPanel", {
-                    tocTemplate: "../../src/lib/infusion/src/components/tableOfContents/html/TableOfContents.html",
-                    templatePrefix: "../../src/lib/infusion/src/framework/preferences/html/",
-                    messagePrefix: "../../src/lib/infusion/src/framework/preferences/messages/",
-                    components: {
-                        prefsEditorLoader: {
-                            options: {
-                                iframeRenderer: {
-                                    markupProps: {
-                                        src: "html/SeparatedPanelPrefsEditorFrame.html"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                });
-
-                gpii.metadata.feedback(".gpiic-feedback", {
-                    resources: {
-                        template: {
-                            url: "../../src/components/feedback/html/feedbackTemplate.html"
-                        }
-                    },
-                    matchConfirmationTemplate: "../../src/components/feedback/html/matchConfirmationTemplate.html"
-                });
-            });
-        </script>
     </body>
 </html>

--- a/demos/feedback/js/feedbackDemo.js
+++ b/demos/feedback/js/feedbackDemo.js
@@ -52,7 +52,7 @@ var demo = demo || {};
             },
             markup: {
                 description: "The FLOE metadata feedback tool can be integrated into existing sites to allow users to provide feedback about how a resource matched their preferences and to request alternatives or modifications to improve it. For the purposes of this demo, the feedback tool is shown within a simple OER.",
-                instructions: "<p>The feedback tool is located along the top of the page</p><ul><li>Use the <span class='gpii-icon gpii-icon-matchConfirmation'></span> to confirm that the resource matches your preferences.</li><li>Use the <span class='gpii-icon gpii-icon-sad'></span> to indicated that the resource does not match your preferences and indicate the issue(s).</li><li>Use the <span class='gpii-icon gpii-icon-request'></span> to view the set of requests made against the resource and to vote for the requests that you are also interested in.</li></ul>"
+                instructions: "<p>The feedback tool is located along the top of the page</p><ul><li>Use the <span class='gpii-icon gpii-icon-matchConfirmation'></span> to confirm that the resource matches your preferences.</li><li>Use the <span class='gpii-icon gpii-icon-sad'></span> to indicated that the resource does not match your preferences and indicate the issue you are encountering.</li><li>Use the <span class='gpii-icon gpii-icon-request'></span> to view the set of requests made against the resource and to vote for the requests that you are also interested in.</li></ul>"
             },
             links: {
                 "titleLink": "http://wiki.fluidproject.org/display/fluid/%28Floe%29+Metadata+Authoring+and+Feedback+Tools",

--- a/demos/feedback/js/feedbackDemo.js
+++ b/demos/feedback/js/feedbackDemo.js
@@ -1,0 +1,77 @@
+/*
+
+Copyright 2014 OCAD University
+
+Licensed under the Educational Community License (ECL), Version 2.0 or the New
+BSD license. You may not use this file except in compliance with one these
+Licenses.
+
+You may obtain a copy of the ECL 2.0 License and BSD License at
+https://github.com/fluid-project/infusion/raw/master/Infusion-LICENSE.txt
+*/
+
+var demo = demo || {};
+
+(function ($, fluid) {
+    "use strict";
+
+    $(document).ready(function () {
+
+        // User Interface Options
+        fluid.uiOptions.prefsEditor(".flc-prefsEditor-separatedPanel", {
+            tocTemplate: "../../src/lib/infusion/src/components/tableOfContents/html/TableOfContents.html",
+            templatePrefix: "../../src/lib/infusion/src/framework/preferences/html/",
+            messagePrefix: "../../src/lib/infusion/src/framework/preferences/messages/",
+            components: {
+                prefsEditorLoader: {
+                    options: {
+                        iframeRenderer: {
+                            markupProps: {
+                                src: "html/SeparatedPanelPrefsEditorFrame.html"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        // Overview Panel
+        fluid.overviewPanel(".flc-overviewPanel", {
+            resources: {
+                template: {
+                    href: "html/overviewPanelTemplate.html"
+                }
+            },
+            strings: {
+                titleBegin: "A",
+                titleLinkText: "Metadata",
+                componentName: "FLOE Metadata Feedback Tool",
+                infusionCodeLinkText: "get Metadata",
+                feedbackText: "Found a bug? Have a question?",
+                feedbackLinkText: "Let us know!"
+            },
+            markup: {
+                description: "The FLOE metadata feedback tool can be integrated into existing sites to allow users to provide feedback about how a resource matched their preferences and to request alternatives or modifications to improve it. For the purposes of this demo, the feedback tool is shown within a simple OER.",
+                instructions: "<p>The feedback tool is located along the top of the page</p><ul><li>Use the <span class='gpii-icon gpii-icon-matchConfirmation'></span> to confirm that the resource matches your preferences.</li><li>Use the <span class='gpii-icon gpii-icon-sad'></span> to indicated that the resource does not match your preferences and indicate the issue(s).</li><li>Use the <span class='gpii-icon gpii-icon-request'></span> to view the set of requests made against the resource and to vote for the requests that you are also interested in.</li></ul>"
+            },
+            links: {
+                "titleLink": "http://wiki.fluidproject.org/display/fluid/%28Floe%29+Metadata+Authoring+and+Feedback+Tools",
+                "demoCodeLink": "https://github.com/fluid-project/metadata/tree/master/demos/feedback",
+                "infusionCodeLink": "https://github.com/fluid-project/metadata",
+                "designLink": "http://wiki.fluidproject.org/display/fluid/Metadata+Feedback+Tool+Design",
+                "feedbackLink": "mailto:infusion-users@fluidproject.org?subject=FLOE Metadata Feedback Tool feedback"
+            }
+        });
+
+        // Feedback Tool
+        gpii.metadata.feedback(".gpiic-feedback", {
+            resources: {
+                template: {
+                    url: "../../src/components/feedback/html/feedbackTemplate.html"
+                }
+            },
+            matchConfirmationTemplate: "../../src/components/feedback/html/matchConfirmationTemplate.html"
+        });
+    });
+
+})(jQuery, fluid);

--- a/demos/metadata/css/metadataDemo.css
+++ b/demos/metadata/css/metadataDemo.css
@@ -418,20 +418,3 @@
     width: 100%;
     font-size: 1em;
 }
-
-
-/* Overview Panel tweaks - Needed due to FLUID-5464 */
-
-.gpii-metadataDemo-demo .fl-overviewPanel-container {
-    z-index: 1;
-    line-height: 1.6rem;
-}
-
-.gpii-metadataDemo-demo .fl-overviewPanel h1 {
-    color: #ccc;
-    font-family: 'RobotoSlab';
-}
-
-.gpii-metadataDemo-demo .fl-overviewPanel-instructions h2 {
-    color: #fff;
-}

--- a/demos/metadata/css/metadataDemo.css
+++ b/demos/metadata/css/metadataDemo.css
@@ -21,6 +21,10 @@
          url('../../shared/fonts/gpii-metadataDemo.ttf');
 }
 
+body {
+    line-height: 1.6;
+}
+
 .gpii-metadataDemo-demo {
     font-family: "OpenSans","Helvetica Neue","Helvetica",Helvetica,Arial,sans-serif;
     background-color: #F4F4E9;

--- a/demos/metadata/index.html
+++ b/demos/metadata/index.html
@@ -9,6 +9,7 @@
         <link rel="stylesheet" href="../../src/lib/normalize/normalize.css" />
         <link rel="stylesheet" href="../lib/foundation/css/foundation.min.css" />
         <link rel="stylesheet" href="../../src/lib/infusion/src/components/overviewPanel/css/OverviewPanel.css" />
+        <link rel="stylesheet" href="../shared/css/overviewPanel.css" />
         <link rel="stylesheet" href="css/metadataDemo.css" />
 
         <script type="text/javascript" src="../../src/lib/infusion/infusion-custom.js"></script>
@@ -20,7 +21,7 @@
         <script type="text/javascript" src="js/launcher.js"></script>
 
     </head>
-    <body class="gpii-metadataDemo-demo">
+    <body class="gpii-metadataDemo-demo gpii-demo">
         <div class="gpiic-overviewPanel fl-overviewPanel-container"></div>
 
         <header class="gpii-metadataDemo-header">

--- a/demos/metadata/js/overview.js
+++ b/demos/metadata/js/overview.js
@@ -71,7 +71,10 @@ var demo = demo || {};
         demo.metadata.overview(".gpiic-overviewPanel", {
             overviewPanelTemplate: "../../src/lib/infusion/src/components/overviewPanel/html/overviewPanelTemplate.html",
             strings: {
+                "titleBegin": "A",
+                "titleLinkText": "Metadata",
                 "componentName": "FLOE Metadata Authoring",
+                "infusionCodeLinkText": "get Metadata",
                 "feedbackText": "Found a bug? Have a question?",
                 "feedbackLinkText": "Let us know!"
             },
@@ -90,7 +93,8 @@ var demo = demo || {};
 
             },
             links: {
-                "demoCodeLink": "https://github.com/fluid-project/metadata/tree/master/demos",
+                "titleLink": "http://wiki.fluidproject.org/display/fluid/%28Floe%29+Metadata+Authoring+and+Feedback+Tools",
+                "demoCodeLink": "https://github.com/fluid-project/metadata/tree/master/demos/metadata",
                 "infusionCodeLink": "https://github.com/fluid-project/metadata",
                 "apiLink": "http://wiki.fluidproject.org/display/fluid/Metadata+API",
                 "designLink": "http://wiki.fluidproject.org/display/fluid/FLOE+Metadata+Authoring+Design",

--- a/demos/metadata/resource.html
+++ b/demos/metadata/resource.html
@@ -8,6 +8,7 @@
         <!-- Custom build of Foundation -->
         <link rel="stylesheet" href="../lib/foundation/css/foundation.min.css" />
         <link rel="stylesheet" href="../../src/lib/infusion/src/components/overviewPanel/css/OverviewPanel.css" />
+        <link rel="stylesheet" href="../shared/css/overviewPanel.css" />
         <link rel="stylesheet" href="css/metadataDemo.css" />
         <link rel="stylesheet" href="../../src/components/metadata/css/metadata.css" />
         <link rel="stylesheet" href="../lib/highlight/styles/github.css" />
@@ -42,7 +43,7 @@
         <script type="text/javascript" src="js/viewer.js"></script>
         <script type="text/javascript" src="js/markupViewer.js"></script>
     </head>
-    <body class="gpiic-metadataDemo-demo gpii-metadataDemo-demo">
+    <body class="gpiic-metadataDemo-demo gpii-metadataDemo-demo gpii-demo">
         <div class="gpiic-overviewPanel fl-overviewPanel-container"></div>
 
         <header class="gpii-metadataDemo-header">

--- a/demos/shared/css/overviewPanel.css
+++ b/demos/shared/css/overviewPanel.css
@@ -5,10 +5,6 @@
 
 /* Overview Panel tweaks - Needed due to FLUID-5464 */
 
-.gpii-demo .fl-overviewPanel-container {
-    line-height: 1.6rem;
-}
-
 .gpii-demo .fl-overviewPanel h1 {
     font-weight: bold;
     color: #ccc;

--- a/demos/shared/css/overviewPanel.css
+++ b/demos/shared/css/overviewPanel.css
@@ -21,6 +21,10 @@
     padding: 0.25rem;
 }
 
+.gpii-demo .fl-overviewPanel-instructions ul {
+    line-height: inherit;
+}
+
 /* adjust the size of the `*` icon to fit inside the feedback bar */
 .gpii-feedbackDemo .fl-overviewPanel-hidden .fl-overviewPanel-icon-fluidStar a {
     padding: 0.52rem 0.3rem;

--- a/demos/shared/css/overviewPanel.css
+++ b/demos/shared/css/overviewPanel.css
@@ -18,3 +18,9 @@
 .gpii-demo .fl-overviewPanel-instructions h2 {
     color: #fff;
 }
+
+.gpii-demo .fl-overviewPanel-instructions .gpii-icon:before {
+    font-size: 1rem;
+    border-color: #fff;
+    padding: 0.25rem;
+}

--- a/demos/shared/css/overviewPanel.css
+++ b/demos/shared/css/overviewPanel.css
@@ -1,0 +1,20 @@
+@font-face {
+    font-family: 'RobotoSlab';
+    src: url('fonts/RobotoSlab-Bold.ttf');
+}
+
+/* Overview Panel tweaks - Needed due to FLUID-5464 */
+
+.gpii-demo .fl-overviewPanel-container {
+    line-height: 1.6rem;
+}
+
+.gpii-demo .fl-overviewPanel h1 {
+    font-weight: bold;
+    color: #ccc;
+    font-family: 'RobotoSlab';
+}
+
+.gpii-demo .fl-overviewPanel-instructions h2 {
+    color: #fff;
+}

--- a/demos/shared/css/overviewPanel.css
+++ b/demos/shared/css/overviewPanel.css
@@ -25,7 +25,18 @@
     line-height: inherit;
 }
 
+.gpii-feedbackDemo .fl-overviewPanel .fl-overviewPanel-icon-fluidStar a {
+    background-color: transparent;
+    outline: none;
+}
+
 /* adjust the size of the `*` icon to fit inside the feedback bar */
 .gpii-feedbackDemo .fl-overviewPanel-hidden .fl-overviewPanel-icon-fluidStar a {
     padding: 0.52rem 0.3rem;
+    background-color: rgba(51, 51, 51, 0.96);
+    outline: 0.2em solid rgba(51, 51, 51, 0.96);
+}
+
+.gpii-feedbackDemo .fl-overviewPanel-hidden .fl-overviewPanel-icon-fluidStar a.fl-link-enhanced {
+    padding: 0.15rem 0.3rem;
 }

--- a/demos/shared/css/overviewPanel.css
+++ b/demos/shared/css/overviewPanel.css
@@ -20,3 +20,8 @@
     border-color: #fff;
     padding: 0.25rem;
 }
+
+/* adjust the size of the `*` icon to fit inside the feedback bar */
+.gpii-feedbackDemo .fl-overviewPanel-hidden .fl-overviewPanel-icon-fluidStar a {
+    padding: 0.52rem 0.3rem;
+}


### PR DESCRIPTION
Also performed some textual and link updates to the metadata authoring tool's overview panel to make things more consistent and accurate. Some minor refactoring to put the shared css into the shared directory.

http://issues.fluidproject.org/browse/FLOE-208
